### PR TITLE
chore: Updating Python Requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ code-annotations==1.3.0
     # via edx-lint
 commonmark==0.9.1
     # via rich
-cryptography==38.0.2
+cryptography==38.0.1
     # via secretstorage
 diff-cover==7.0.1
     # via -r requirements/dev.in
@@ -69,7 +69,7 @@ docutils==0.19
     # via readme-renderer
 edx-django-utils==5.2.0
     # via django-config-models
-edx-i18n-tools==0.9.1
+edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
 edx-lint==5.3.0
     # via
@@ -107,7 +107,7 @@ markupsafe==2.1.1
     # via jinja2
 mccabe==0.7.0
     # via pylint
-more-itertools==8.14.0
+more-itertools==9.0.0
     # via jaraco-classes
 newrelic==8.2.1
     # via edx-django-utils
@@ -131,7 +131,7 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-psutil==5.9.2
+psutil==5.9.3
     # via edx-django-utils
 py==1.11.0
     # via tox
@@ -166,7 +166,7 @@ pyparsing==3.0.9
     # via packaging
 python-slugify==6.1.2
     # via code-annotations
-pytz==2022.4
+pytz==2022.5
     # via
     #   django
     #   djangorestframework
@@ -198,7 +198,7 @@ snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.4.3
     # via django
-stevedore==4.0.0
+stevedore==4.0.1
     # via
     #   code-annotations
     #   edx-django-utils

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.2.2
+pip==22.3
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -81,7 +81,7 @@ six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0
     # via pydocstyle
-stevedore==4.0.0
+stevedore==4.0.1
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -42,7 +42,7 @@ pbr==5.10.0
     # via stevedore
 pluggy==1.0.0
     # via pytest
-psutil==5.9.2
+psutil==5.9.3
     # via edx-django-utils
 py==1.11.0
     # via pytest
@@ -60,11 +60,11 @@ pytest-cov==4.0.0
     # via -r requirements/test.in
 pytest-django==4.5.2
     # via -r requirements/test.in
-pytz==2022.4
+pytz==2022.5
     # via djangorestframework
 sqlparse==0.4.3
     # via django
-stevedore==4.0.0
+stevedore==4.0.1
     # via edx-django-utils
 tomli==2.0.1
     # via


### PR DESCRIPTION
The scheduled upgrade requirements workflow [build](https://github.com/openedx/django-splash/actions/runs/3278393092/jobs/5398689116#step:7:68) failed to create pull request so created the PR manually.